### PR TITLE
升级fastjson版本到1.2.83,1.2.83版本之前存在代码执行漏洞风险，CVE-2022-25845

### DIFF
--- a/7_engine_hub/voiceprint_search/voiceprint-search/pom.xml
+++ b/7_engine_hub/voiceprint_search/voiceprint-search/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <jna.version>5.6.0</jna.version>
         <djl.version>0.17.0</djl.version>
-        <fastjson.version>1.2.70</fastjson.version>
+        <fastjson.version>1.2.83</fastjson.version>
         <swagger.version>2.9.2</swagger.version>
         <hutool.version>5.3.4</hutool.version>
     </properties>


### PR DESCRIPTION
升级fastjson版本到1.2.83,1.2.83版本之前存在代码执行漏洞风险，CVE-2022-25845