### PR TITLE
升级fastjson版本到1.2.83,1.2.83版本之前存在代码执行漏洞风险，CVE-2022-25845

### DIFF
--- a/8_suite_hub/bio_tech/dna_sequence_search/dna_sequence_search/pom.xml
+++ b/8_suite_hub/bio_tech/dna_sequence_search/dna_sequence_search/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <jna.version>5.6.0</jna.version>
-        <fastjson.version>1.2.70</fastjson.version>
+        <fastjson.version>1.2.83</fastjson.version>
         <swagger.version>2.9.2</swagger.version>
         <hutool.version>5.3.4</hutool.version>
     </properties>


### PR DESCRIPTION
升级fastjson版本到1.2.83,1.2.83版本之前存在代码执行漏洞风险，CVE-2022-25845